### PR TITLE
Re-init watch whenever we get IN_IGNORED for a path

### DIFF
--- a/beacons/managedwatch.py
+++ b/beacons/managedwatch.py
@@ -83,6 +83,13 @@ class EventHandler(pyinotify.ProcessEvent):
                 auto_add=True)
         self.notifier.start()
 
+    def process_IN_IGNORED(self, event):
+        # Re-init the watch after IN_IGNORED
+        log.debug("IN_IGNORED: re-init the watch for: %s" % event.pathname)
+        self.wm.add_watch(
+            event.pathname, pyinotify.IN_MODIFY | pyinotify.IN_DELETE_SELF,
+            auto_add=True)
+
     def process_default(self, event):
         # Does nothing, just to demonstrate how stuffs could be done
         # after having processed statistics.


### PR DESCRIPTION
When you save a file in vim you get IN_DELETE_SELF and an IN_IGNORED event afterwards. The beacon basically stops watching the file there, so we probably want to re-init the watch by calling `add_watch()` again for this path.
