### PR TITLE
Do not crash when there is no diff

### DIFF
--- a/beacons/managedwatch.py
+++ b/beacons/managedwatch.py
@@ -38,7 +38,7 @@ class ManagedFile:
         if len(vals) != 1:
             log.warning('More than one sls for the id: %s' % self.id)
             return ""
-        if 'changes' in vals[0]:
+        if 'changes' in vals[0] and 'diff' in vals[0]['changes']:
             return vals[0]['changes']['diff']
         return ""
 


### PR DESCRIPTION
There might be a change without a diff, for instance when a file is replaced with its original version. We can think about what to do in such cases, but for now this patch should at least prevent the beacon from crashing since a restart of the minion seems to be necessary to recover from this crash!
